### PR TITLE
API: add attachment validation to only allow single document per type…

### DIFF
--- a/drr/src/API/EMCR.DRR/Services/S3/Contract.cs
+++ b/drr/src/API/EMCR.DRR/Services/S3/Contract.cs
@@ -24,6 +24,11 @@
         public FileTag? FileTag { get; set; }
     }
 
+    public class UpdateTagsCommand : StorageCommand
+    {
+        public FileTag? FileTag { get; set; }
+    }
+
     public abstract class StorageQuery
     {
         public string Key { get; set; } = null!;


### PR DESCRIPTION
… that is not 'Other'. Tag deleted files in S3