### PR TITLE
API: base64 encode S3 file name header to allow support of additional…

### DIFF
--- a/drr/src/API/EMCR.DRR/Program.cs
+++ b/drr/src/API/EMCR.DRR/Program.cs
@@ -178,7 +178,9 @@ services.AddAuthentication(options =>
 {
     options.DefaultScheme = defaultScheme;
     options.DefaultChallengeScheme = defaultScheme;
-}).AddJwtBearer(JwtBearerDefaults.AuthenticationScheme, options =>
+})
+//For portal users
+.AddJwtBearer(JwtBearerDefaults.AuthenticationScheme, options =>
 {
     options.MetadataAddress = configuration.GetValue<string>("jwt:metadataAddress");
     options.TokenValidationParameters = new TokenValidationParameters
@@ -218,6 +220,7 @@ services.AddAuthentication(options =>
     };
     options.Validate();
 })
+//For CRM service account to use our S3 integration
 .AddJwtBearer("SSO", options =>
 {
     options.MetadataAddress = configuration.GetValue<string>("SSO:jwt:metadataAddress");

--- a/drr/src/API/EMCR.Test.Integration.DRR.Api/S3Storage/S3StorageTests.cs
+++ b/drr/src/API/EMCR.Test.Integration.DRR.Api/S3Storage/S3StorageTests.cs
@@ -16,15 +16,18 @@ namespace EMCR.Tests.Integration.DRR.Api.S3Storage
             var storageProvider = host.Services.GetRequiredService<IS3Provider>();
 
             var body = DateTime.Now.ToString();
-            var fileName = "test.txt";
+            var key = "autotest-file-key";
+            var fileName = "ᓀᐦᐃᔭᐍᐏᐣ (Nēhiyawēwin).txt";
             byte[] bytes = Encoding.ASCII.GetBytes(body);
             var file = new S3File { FileName = fileName, Content = bytes, ContentType = "text/plain", };
 
-            var ret = await storageProvider.HandleCommand(new UploadFileCommand { Folder = "autotest-dev", Key = fileName, File = file });
-            ret.ShouldBe(fileName);
+            var ret = await storageProvider.HandleCommand(new UploadFileCommand { Folder = "autotest-dev", Key = key, File = file });
+            ret.ShouldBe(key);
 
-            var uploadedFile = await storageProvider.HandleQuery(new FileQuery { Key = fileName, Folder = "autotest-dev" });
+            var uploadedFile = await storageProvider.HandleQuery(new FileQuery { Key = key, Folder = "autotest-dev" });
             uploadedFile.ShouldNotBeNull().ShouldBeOfType<FileQueryResult>();
+            var fileRes = (FileQueryResult)uploadedFile;
+            fileRes.File.FileName.ShouldBe(fileName);
         }
 
 #pragma warning disable CS8602 // Dereference of a possibly null reference.


### PR DESCRIPTION
… special characters. Include handling of existing files that won't have base64 encoded names